### PR TITLE
Fix broken history

### DIFF
--- a/src/disable-amp.js
+++ b/src/disable-amp.js
@@ -21,7 +21,7 @@ function preventAmp() {
             e.preventDefault();
             e.stopPropagation();
             const url = el.getAttribute('data-amp-cur');
-            document.location.replace(url);
+            document.location.href = url;
         }, true);
     });
 }


### PR DESCRIPTION
"document.location.replace" cause the overwrite of current page and avoid the creation of a new element in history.